### PR TITLE
Skip nodes and better navigation

### DIFF
--- a/fan_app_interface/lib/features/navigation/domain/dynamic_route_manager.dart
+++ b/fan_app_interface/lib/features/navigation/domain/dynamic_route_manager.dart
@@ -20,6 +20,9 @@ class DynamicRouteManager {
   RouteModel? _currentRoute;
   Timer? _recalculationTimer;
 
+  // Debounce: instante em que o user saiu da rota pela primeira vez
+  DateTime? _firstOffRouteTime;
+
   // Callbacks
   Function(RouteModel)? onRouteUpdated;
 
@@ -38,8 +41,9 @@ class DynamicRouteManager {
   /// Atualiza manualmente a rota atual (ex: por rerouting MQTT)
   void updateRoute(RouteModel newRoute) {
     _currentRoute = newRoute;
-    // Reiniciar timer para evitar conflitos imediatos
+    // Reiniciar timer e debounce para evitar conflitos imediatos
     _recalculationTimer?.cancel();
+    _firstOffRouteTime = null;
   }
 
   /// Inicia monitorização automática da posição
@@ -84,9 +88,28 @@ class DynamicRouteManager {
       '[DynamicRouteManager] Distância à rota: ${minDistanceToRoute.toStringAsFixed(1)}m',
     );
 
-    // Se está a mais de 8 metros da rota, recalcular
-    if (minDistanceToRoute > 8.0) {
-      await _recalculateRoute(userX, userY);
+    // Smart Rerouting: só recalcula se o user estiver >20m da rota
+    // por pelo menos 5 segundos consecutivos (evita drifts de GPS).
+    const double rerouteThreshold = 20.0;
+    const Duration rerouteDebounce = Duration(seconds: 5);
+
+    if (minDistanceToRoute > rerouteThreshold) {
+      _firstOffRouteTime ??= DateTime.now();
+      final offFor = DateTime.now().difference(_firstOffRouteTime!);
+      print(
+        '[DynamicRouteManager] Off-route for ${offFor.inSeconds}s '
+        '(threshold: ${rerouteDebounce.inSeconds}s)',
+      );
+      if (offFor >= rerouteDebounce) {
+        _firstOffRouteTime = null; // reset para próximo evento
+        await _recalculateRoute(userX, userY);
+      }
+    } else {
+      // Voltou à rota — cancelar contagem
+      if (_firstOffRouteTime != null) {
+        print('[DynamicRouteManager] Voltou à rota, debounce cancelado.');
+        _firstOffRouteTime = null;
+      }
     }
   }
 
@@ -162,5 +185,6 @@ class DynamicRouteManager {
 
   void dispose() {
     _recalculationTimer?.cancel();
+    _firstOffRouteTime = null;
   }
 }

--- a/fan_app_interface/lib/features/navigation/domain/navigation_controller.dart
+++ b/fan_app_interface/lib/features/navigation/domain/navigation_controller.dart
@@ -50,6 +50,20 @@ class NavigationController extends ChangeNotifier {
   // Piso atual (baseado no waypoint atual)
   int _currentLevel = 0;
 
+  // ── Filtro de ruído GPS ──────────────────────────────────────────────────
+  // Última posição aceite como válida
+  double? _lastFilteredX;
+  double? _lastFilteredY;
+  DateTime? _lastFilteredTime;
+
+  // Velocidade máxima plausível para um pedrão a correr: 3.5 m/s (~12.6 km/h)
+  // Saltos que impliquem >3× esse valor são descartados como ruído de GPS.
+  static const double _maxPlausibleSpeed = 3.5;  // m/s
+  static const double _noiseMultiplier   = 3.0;
+  // Se o GPS esteve parado > 10 s (ex: récoupération de sinal), aceitar sempre
+  static const Duration _signalGap = Duration(seconds: 10);
+  // ──────────────────────────────────────────────────────────────────────────
+
   NavigationController({
     required RouteModel route,
     required this.destination,
@@ -195,11 +209,46 @@ class NavigationController extends ChangeNotifier {
               _heading = position.heading;
             }
 
+            final newX = position.longitude;
+            final newY = position.latitude;
+
+            // ── Filtro de ruído GPS ──────────────────────────────────────
+            if (_lastFilteredX != null && _lastFilteredTime != null) {
+              final timeDelta = DateTime.now()
+                  .difference(_lastFilteredTime!)
+                  .inMilliseconds / 1000.0;
+
+              // Se há menos de 10 s desde a última posição válida,
+              // verificar se a velocidade implicada é plausível.
+              if (timeDelta < _signalGap.inSeconds.toDouble() && timeDelta > 0) {
+                final dist = GeographicUtils.calculateDistance(
+                  _lastFilteredX!, _lastFilteredY!, newX, newY,
+                );
+                final impliedSpeed = dist / timeDelta; // m/s
+
+                if (impliedSpeed > _maxPlausibleSpeed * _noiseMultiplier) {
+                  print(
+                    '[NavigationController] ⚠️ GPS NOISE ignored: '
+                    'impliedSpeed=${impliedSpeed.toStringAsFixed(1)} m/s '
+                    '(limit=${(_maxPlausibleSpeed * _noiseMultiplier).toStringAsFixed(1)} m/s), '
+                    'jump=${dist.toStringAsFixed(1)}m in ${timeDelta.toStringAsFixed(1)}s',
+                  );
+                  return; // descartar esta posição
+                }
+              }
+            }
+
+            // Posição aceite — actualizar filtro
+            _lastFilteredX = newX;
+            _lastFilteredY = newY;
+            _lastFilteredTime = DateTime.now();
+            // ─────────────────────────────────────────────────────────────
+
             // Update position on map/tracker
-            updateUserPosition(position.longitude, position.latitude);
+            updateUserPosition(newX, newY);
 
             // Emit to trigger dynamic route manager updates
-            _positionStream.add((x: position.longitude, y: position.latitude));
+            _positionStream.add((x: newX, y: newY));
           },
         );
   }

--- a/fan_app_interface/lib/features/navigation/domain/route_tracker.dart
+++ b/fan_app_interface/lib/features/navigation/domain/route_tracker.dart
@@ -299,19 +299,31 @@ class RouteTracker {
     }
   }
 
+  /// Versão do progressAlongSegment sem clamp — permite detectar t > 1
+  /// (user passou além do nó destino do segmento)
+  double _rawProgressAlongSegment(
+    double px, double py,
+    double x1, double y1,
+    double x2, double y2,
+  ) {
+    final segLenSq = (x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1);
+    if (segLenSq < 1e-12) return 1.0;
+    return ((px - x1) * (x2 - x1) + (py - y1) * (y2 - y1)) / segLenSq;
+  }
+
   /// Atualiza o waypoint atual baseado na posição do utilizador.
   ///
   /// Lógica estilo Google Maps:
-  /// 1. Se o user está perto de um waypoint (< 4m), avança
-  /// 2. Se o user progrediu > 90% no segmento atual, avança
-  /// 3. FORWARD-PROJECTION: Se o user está mais perto do PRÓXIMO waypoint
-  ///    do que do ATUAL, avança (skips waypoints ultrapassados)
+  /// 1. Proximidade direta ao nó (< 6m)
+  /// 2. Projeção na linha: se a projeção do user ultrapassou o nó (t ≥ 1.0)
+  ///    o nó é marcado como feito — mesmo que esteja 6m lateral
+  /// 3. Snap-to-edge: progresso > 90% dentro de 12m ao segmento
+  /// 4. Forward-jump: mais perto do próximo waypoint que do atual
   void _updateCurrentWaypoint() {
     if (_currentWaypointIndex >= route.waypoints.length) return;
 
     bool advanced = true;
 
-    // Continuar a avançar enquanto houver waypoints para saltar
     while (advanced && _currentWaypointIndex < route.waypoints.length) {
       advanced = false;
 
@@ -322,14 +334,13 @@ class RouteTracker {
         _userX, _userY, coords.x, coords.y,
       );
 
-      // Debug log
       print(
         '[RouteTracker] WP$currentIdx (${waypoint.nodeId}): '
         'dist=${pointDist.toStringAsFixed(1)}m',
       );
 
-      // === CHECK 1: Proximidade direta ao nó (< 4m) ===
-      if (pointDist < 4.0) {
+      // === CHECK 1: Proximidade direta ao nó (< 6m) ===
+      if (pointDist < 6.0) {
         _currentWaypointIndex = currentIdx + 1;
         print(
           '[RouteTracker] WP$currentIdx atingido por proximidade '
@@ -339,62 +350,75 @@ class RouteTracker {
         continue;
       }
 
-      // === CHECK 2: Snap-to-edge — progresso no segmento ===
+      // === CHECK 2: TRUE FORWARD PROJECTION ===
+      // Projeta a posição do user sobre o segmento anterior → atual.
+      // Se t >= 1.0 a projeção passou o nó, mesmo que o user esteja
+      // vários metros de lado (ex: numa curva, ou GPS drift lateral).
       if (currentIdx > 0) {
         final prevWp = route.waypoints[currentIdx - 1];
         final prevCoords = getCorrectWaypointCoords(prevWp);
 
-        final segDist = GeographicUtils.pointToSegmentDistance(
+        final rawT = _rawProgressAlongSegment(
           _userX, _userY,
           prevCoords.x, prevCoords.y,
           coords.x, coords.y,
         );
-        final progress = GeographicUtils.progressAlongSegment(
+
+        // Distância lateral ao segmento (para evitar falsos positivos em rotas em U)
+        final segDist = GeographicUtils.pointToSegmentDistance(
           _userX, _userY,
           prevCoords.x, prevCoords.y,
           coords.x, coords.y,
         );
 
         print(
-          '[RouteTracker] Seg WP${currentIdx - 1}→WP$currentIdx: '
-          'segDist=${segDist.toStringAsFixed(1)}m, '
-          'progress=${(progress * 100).toStringAsFixed(0)}%',
+          '[RouteTracker] Projection WP${currentIdx-1}→WP$currentIdx: '
+          't=${rawT.toStringAsFixed(2)}, lateral=${segDist.toStringAsFixed(1)}m',
         );
 
-        // Se está perto do segmento E progrediu > 90%, avança
-        if (segDist < 8.0 && progress > 0.90) {
+        // Se a projeção passou o nó (t ≥ 1.0) E o user não está demasiado
+        // longe lateralmente (< 15m — evita rotas em U falsas), avança.
+        if (rawT >= 1.0 && segDist < 15.0) {
+          _currentWaypointIndex = currentIdx + 1;
+          print(
+            '[RouteTracker] WP$currentIdx passed by projection '
+            '(t=${rawT.toStringAsFixed(2)}, lateral=${segDist.toStringAsFixed(1)}m)',
+          );
+          advanced = true;
+          continue;
+        }
+
+        // === CHECK 3: Snap-to-edge — progresso > 90% dentro de 12m ===
+        final clampedProgress = rawT.clamp(0.0, 1.0);
+        if (segDist < 12.0 && clampedProgress > 0.90) {
           _currentWaypointIndex = currentIdx + 1;
           print(
             '[RouteTracker] WP$currentIdx atingido por snap-to-edge '
-            '(progress=${(progress * 100).toStringAsFixed(0)}%)',
+            '(progress=${(clampedProgress * 100).toStringAsFixed(0)}%, '
+            'lateral=${segDist.toStringAsFixed(1)}m)',
           );
           advanced = true;
           continue;
         }
       }
 
-      // === CHECK 3: FORWARD-PROJECTION (estilo Google Maps) ===
-      // Se o user está mais perto do PRÓXIMO waypoint do que do ATUAL,
-      // significa que já ultrapassou o atual sem passar perto.
-      // Isto resolve o caso de cortar uma curva ou caminhar paralelo.
+      // === CHECK 4: FORWARD-JUMP ===
+      // Se o user está mais perto do próximo waypoint do que do atual
+      // e já passou mais de 40% do segmento atual → claramente ultrapassou.
       if (currentIdx + 1 < route.waypoints.length) {
         final nextWp = route.waypoints[currentIdx + 1];
         final nextCoords = getCorrectWaypointCoords(nextWp);
         final distToNext = GeographicUtils.calculateDistance(
           _userX, _userY, nextCoords.x, nextCoords.y,
         );
-
-        // Distância entre o waypoint atual e o próximo
         final segmentLen = GeographicUtils.calculateDistance(
           coords.x, coords.y, nextCoords.x, nextCoords.y,
         );
 
-        // Se o user está mais perto do próximo E a distância ao atual
-        // é maior que metade do segmento → claramente ultrapassou
         if (distToNext < pointDist && pointDist > segmentLen * 0.4) {
           _currentWaypointIndex = currentIdx + 1;
           print(
-            '[RouteTracker] WP$currentIdx skipped (forward-projection): '
+            '[RouteTracker] WP$currentIdx skipped (forward-jump): '
             'distCurrent=${pointDist.toStringAsFixed(1)}m > '
             'distNext=${distToNext.toStringAsFixed(1)}m',
           );


### PR DESCRIPTION
This pull request significantly improves the navigation experience by making route tracking and rerouting both smarter and more robust against GPS noise. The main improvements include a debounce mechanism for rerouting, a GPS noise filter to ignore implausible jumps, and more reliable logic for waypoint advancement, especially in cases of GPS drift or user shortcuts.

**Navigation Robustness and Rerouting Improvements:**

* Added a debounce mechanism to `DynamicRouteManager` so that rerouting is only triggered if the user is more than 20 meters off-route for at least 5 seconds, reducing false reroutes due to GPS drift. The debounce state is reset when the user returns to the route or when a new route is set. (`dynamic_route_manager.dart`) 

* Implemented a GPS noise filter in `NavigationController` to ignore position updates that imply speeds greater than 3× a plausible running speed (3.5 m/s), unless there has been a GPS signal gap of over 10 seconds. This helps prevent erratic jumps due to GPS errors. (`navigation_controller.dart`) 

**Waypoint Advancement and Route Tracking Logic:**

* Refined the waypoint advancement logic in `RouteTracker`:
  - Added a new `_rawProgressAlongSegment` method to detect when a user has passed a waypoint even if not directly near it.
  - Increased the proximity threshold for direct node detection from 4m to 6m.
  - Introduced a "true forward projection" check: if the user's projected position along the segment passes the waypoint (t ≥ 1.0) and is within 15m laterally, the waypoint is considered reached.
  - Adjusted the "snap-to-edge" logic to advance the waypoint if progress is >90% within 12m of the segment.
  - Improved the "forward-jump" check to advance the waypoint if the user is closer to the next waypoint and has passed 40% of the current segment. (`route_tracker.dart`) 

These changes together make the navigation system more tolerant of real-world GPS issues and user behavior, ensuring smoother and more accurate route tracking.